### PR TITLE
Replace Vuex state before mounting the component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,7 @@ export const renderVuex = (
         const { propsData, state } = data;
 
         const store = createStore();
+        store.replaceState(state);
 
         const Component: VueConstructor = Vue.extend({
           ...ComponentDefinition,
@@ -107,8 +108,6 @@ export const renderVuex = (
         });
 
         const vm = mountComponent(Component, node, propsData) as VueWithStoreInstance;
-
-        vm.$store.replaceState(state);
       });
     }
 


### PR DESCRIPTION
The Vuex state should be restored before mounting the component otherwise Vue will try to render a component with different state to what was server rendered.